### PR TITLE
Add iRaiser Connector documentation in Spanish and French

### DIFF
--- a/docs/documentation-api/9 - Data Connector Module/3-data-connector-module-configuration.md
+++ b/docs/documentation-api/9 - Data Connector Module/3-data-connector-module-configuration.md
@@ -87,7 +87,7 @@ Once the steps above are completed, continue with the configuration guide for yo
 | Data Connector | Documentation |
 |----------------|--------------|
 | **Recherche Entreprise** | [View Guide](./5-dcm-recherche-entreprise-configuration.md) |
-| **iRaiser** | *(Coming soon)* |
+| **iRaiser** | [View Guide](./7-iraiser-connector-introduction.md) |
 
 📌 Each connector may require additional setup steps depending on its API structure and business use case.
 

--- a/docs/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
+++ b/docs/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
@@ -1,0 +1,54 @@
+# iRaiser Connector
+
+## Introduction
+
+The **iRaiser Connector** allows Salesforce users to receive real-time donation and supporter data from iRaiser directly into Salesforce through secure webhook integration. Unlike other Data Connectors that use a search-based approach where users actively retrieve data, the iRaiser Connector operates on a **push-based model** where iRaiser automatically sends data to Salesforce whenever changes occur.
+
+🌐 iRaiser Documentation: https://www.iraiser.eu/
+
+> ✅ Typical use case: Automatically create or update **Contact**, **Account**, **Opportunity** or custom donor records in Salesforce when donations or supporter information are created or modified in iRaiser.
+
+---
+
+## How Does It Work?
+
+### Webhook Integration
+
+The iRaiser Connector receives data from iRaiser via HTTP POST webhook calls. When an event occurs in iRaiser (such as a new donation, contact update, or recurring payment), iRaiser sends the data to a designated endpoint in Salesforce.
+
+The connector:
+1. Validates the incoming request using token-based authentication
+2. Processes the JSON payload from iRaiser
+3. Matches or creates records in the appropriate Salesforce objects
+4. Handles parent-child relationships automatically
+5. Logs all activities for monitoring and troubleshooting
+
+### Authentication
+
+The connector uses **token-based authentication** to secure webhook communications. A shared secret token configured in Salesforce is used to validate each incoming request from iRaiser.
+
+Each request includes three security headers that are validated:
+- `securelogin` — iRaiser login/username
+- `securetimestamp` — Current UTC timestamp
+- `securetoken` — MD5 hash generated from the token and request details
+
+> ℹ️ Authentication is handled automatically by the connector. No client-side configuration is required.
+
+### Data Flow
+
+The iRaiser Connector processes data through these key custom objects:
+
+- **[Data Connector](3-data-connector-module-configuration.md#create-a-data-connector)** – Identifies this as an iRaiser integration by defining the connector type.
+- **[Data Table Definition](8-iraiser-connector-configuration.md#data-table-definition)** – Links the connector to Salesforce objects (Example: Contact, Account, Opportunity) and defines parent-child relationships.
+- **[Data Attribute Mapping](8-iraiser-connector-configuration.md#data-attribute-mappings)** – Maps fields from the iRaiser JSON payload to Salesforce fields, defining how data is imported into Salesforce records.
+
+### Asynchronous Processing
+
+To ensure scalability and reliability, the connector uses Salesforce **Platform Events** for asynchronous processing. This means:
+
+- Webhook requests are accepted immediately (HTTP 202 response)
+- Actual record processing happens in the background
+- High volumes of data can be handled without impacting user experience
+- Failed operations are automatically retried
+
+---

--- a/docs/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
+++ b/docs/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
@@ -1,0 +1,398 @@
+# iRaiser Connector Configuration
+
+## Overview
+
+> ⚠️ **Prerequisite:** Before configuring this connector, make sure the **General Configuration** is completed.  
+> See [General Configuration](3-data-connector-module-configuration.md) for steps on assigning permission sets and creating a Data Connector.
+
+1. [**Create the Data Connector**](#data-connector) – Set up the connector record with type "iRaiser Connector"
+2. [**Store the iRaiser Token**](#store-the-iraiser-token) – Configure the security token in Settings
+3. [**Create Data Table Definitions**](#data-table-definition) – Link iRaiser data to Salesforce objects
+4. [**Configure Data Attribute Mappings**](#data-attribute-mappings) – Map iRaiser JSON fields to Salesforce fields
+5. [**Create the Public Site for Webhook Reception**](#create-the-public-site-for-webhook-reception) – Enable webhook reception
+
+In the next section, we'll take a closer look at each of these configuration steps.
+
+---
+
+## Data Connector
+
+### Create the Data Connector Record
+
+The Data Connector record identifies this as an iRaiser integration.
+
+#### Required Fields
+
+| Field | Meaning | Value to Set |
+|-------|--------|--------------------------|
+| **Name** | Unique identifier for this connector | Example: `iRaiser Production` or `iRaiser Sandbox` |
+| **Connector Type** | Type of connector | Select `iRaiser Connector` from the picklist |
+
+#### Example Configuration
+
+| Field | Example Value |
+|-------|---------------|
+| Name | `iRaiser Production` |
+| Connector Type | `iRaiser Connector` |
+
+#### Steps
+
+1. Go to **Data Connectors** tab
+2. Click **New**
+3. Enter a Name (e.g., "iRaiser Production")
+4. Select `iRaiser Connector` as the Connector Type
+5. Save the record
+
+---
+
+## Store the iRaiser Token
+
+### Configure the Security Token
+
+The iRaiser Connector uses a shared secret token to validate incoming webhook requests. This token must be configured in the Mobee Settings custom metadata.
+
+#### Required Fields
+
+| Field | Meaning | Value to Set |
+|-------|--------|--------------------------|
+| **iRaiser Token** | Shared secret key for webhook authentication | The token provided by iRaiser |
+
+#### Steps
+
+1. Go to **Setup** → **Custom Metadata Types**
+2. Click **Manage Records** next to **Mobee Settings**
+3. Edit the default **Settings** record (or create a new one)
+4. Enter the iRaiser Token in the **iRaiser Token** field
+5. Save the record
+
+> 🔐 **Security Note:** This token is used to validate the `securetoken` header in incoming webhook requests. Keep it secure and never expose it in client-side code.
+
+---
+
+## Data Table Definition
+
+### Overview
+
+Data Table Definitions link iRaiser data to Salesforce objects. For the iRaiser Connector, each definition specifies which Salesforce object will receive data from the webhook payload.
+
+The connector supports processing multiple objects in a single webhook call, with automatic handling of parent-child relationships.
+
+### Required Fields
+
+| Field | Meaning | Value to Set |
+|-------|--------|--------------------------|
+| **Data Connector** | Links this table definition to the connector | Select your iRaiser Connector |
+| **Object Name** | The Salesforce object where records will be created/updated | Type the Object API Name. Example: `Account`, `Contact`, `Opportunity` |
+| **Object Record Type** *(optional)* | Limits processing to specific record types | Developer Names separated by commas |
+| **Parent Table Lookup Mapping** *(optional)* | Defines parent-child relationships for hierarchical processing | Format: `ParentObjectAPI->ChildLookupField` (one per line) |
+
+> 💡 If your org does **not** use record types on the designated object, leave **Object Record Type** blank.  
+> When filling **Object Record Type**, enter the **Developer Name**, not the label.  
+> Example: `Business_Account, PersonAccount`
+
+### Example Configuration
+
+#### For a Contact Object (Child of Account)
+
+| Field | Example Value |
+|-------|---------------|
+| Data Connector | *iRaiser Production* |
+| Object Name | `Contact` |
+| Object Record Type | (blank) |
+| Parent Table Lookup Mapping | `Account->AccountId` |
+
+#### For an Account Object (Root)
+
+| Field | Example Value |
+|-------|---------------|
+| Data Connector | *iRaiser Production* |
+| Object Name | `Account` |
+| Object Record Type | `Business_Account` |
+| Parent Table Lookup Mapping | (blank - this is a root object) |
+
+#### For an Opportunity Object (Child of Account and Contact)
+
+| Field | Example Value |
+|-------|---------------|
+| Data Connector | *iRaiser Production* |
+| Object Name | `Opportunity` |
+| Object Record Type | `Donation` |
+| Parent Table Lookup Mapping | `Account->AccountId` |
+
+### Steps
+
+1. Go to **Data Table Definitions** tab
+2. Click **New**
+3. Select your iRaiser Connector in the **Data Connector** field
+4. Enter the Salesforce **Object Name** (API name)
+5. Optionally specify **Object Record Type** if you need to filter by record type
+6. If this object has parent relationships, configure the **Parent Table Lookup Mapping**
+7. Save the record
+
+---
+
+## Data Attribute Mappings
+
+### Overview
+
+Data Attribute Mappings define how fields from the iRaiser JSON payload map to Salesforce object fields. The iRaiser Connector uses **dot notation** to access nested fields in the JSON structure.
+
+> 💡 Only fields with the appropriate mappings will be populated in Salesforce records. Each mapping links a specific JSON path to a Salesforce field.
+
+### Key Fields
+
+| Field | Meaning | Value to Set |
+|-------|--------|-------------|
+| **Data Table Definition** | Links this mapping to the corresponding data table definition | Select the related *Data Table Definition* record |
+| **SF Object Field** | Salesforce field where the value should be stored | Developer Name of the field (Example: `FirstName`, `LastName`, `Email`) |
+| **API Field** | Field path from the iRaiser JSON payload | JSON field path using dot notation (Example: `contact.firstname`, `contact.lastname`) |
+| **Is Unique Identifier** | Marks this field as a unique identifier for record matching | Check for fields that uniquely identify records (e.g., iRaiser ID, Email) |
+
+#### 1. Setting the SF Object Field in the Data Attribute Mapping
+
+- This is the internal API name of the Salesforce field you want to populate.
+- It must exist on the object associated with your Data Table Definition.
+- You can find it in **Object Manager → [Your Object] → Fields & Relationships**.
+
+📌 <u>*Example:*</u>
+
+To map the Contact's first name, set the **SF Object Field** to `FirstName`.
+
+#### 2. Setting the API Field in the Data Attribute Mapping
+
+This is the exact field path as returned by the iRaiser API, using **dot notation** to access nested objects.
+
+- Use dot notation to traverse the JSON structure
+- Make sure the field exists in the webhook payload
+
+📌 <u>*Example:*</u>
+
+<details>
+<summary>View iRaiser JSON payload example</summary>
+
+```json
+Example of webhook payload:
+
+{
+  "event": "contact.updated",
+  "data": {
+    "contact": {
+      "id": "12345",
+      "firstname": "John",
+      "lastname": "Doe",
+      "email": "john.doe@example.com",
+      "phone": "+33123456789",
+      "account": {
+        "id": "67890",
+        "name": "Acme Corporation",
+        "address": {
+          "street": "123 Main Street",
+          "city": "Paris",
+          "postalcode": "75001",
+          "country": "France"
+        }
+      }
+    }
+  },
+  "timestamp": "2025-08-17T10:00:00Z"
+}
+```
+
+</details>
+
+| SF Object Field | API Field | Is Unique Identifier |
+|-----------|-------------------|---------------------|
+| FirstName | `contact.firstname` | No |
+| LastName | `contact.lastname` | No |
+| Email | `contact.email` | Yes |
+| Phone | `contact.phone` | No |
+| iRaiser_Id__c | `contact.id` | Yes |
+
+#### 3. Example of Data Attribute Mapping Records
+
+For a Contact object receiving iRaiser data:
+
+| Data Table Definition | SF Object Field | API Field | Is Unique Identifier |
+|---|---|---|---|
+| iRaiser Contact | FirstName | contact.firstname | (unchecked) |
+| iRaiser Contact | LastName | contact.lastname | (unchecked) |
+| iRaiser Contact | Email | contact.email | ✅ (checked) |
+| iRaiser Contact | Phone | contact.phone | (unchecked) |
+| iRaiser Contact | iRaiser_Id__c | contact.id | ✅ (checked) |
+
+For an Account object:
+
+| Data Table Definition | SF Object Field | API Field | Is Unique Identifier |
+|---|---|---|---|
+| iRaiser Account | Name | contact.account.name | (unchecked) |
+| iRaiser Account | iRaiser_Account_Id__c | contact.account.id | ✅ (checked) |
+| iRaiser Account | BillingStreet | contact.account.address.street | (unchecked) |
+| iRaiser Account | BillingCity | contact.account.address.city | (unchecked) |
+| iRaiser Account | BillingPostalCode | contact.account.address.postalcode | (unchecked) |
+
+> 💡 **Best Practice:** Always map the iRaiser external ID (e.g., `contact.id`) to a custom field in Salesforce and mark it as a **Unique Identifier**. This ensures proper record matching across syncs and prevents duplicate records.
+
+---
+
+## Create the Public Site for Webhook Reception
+
+The iRaiser Connector receives webhook calls from iRaiser, which requires a publicly accessible endpoint in Salesforce. This is achieved by creating and activating a Salesforce Site.
+
+> ⚠️ Small differences may appear depending on your Salesforce edition — the principle remains the same.
+
+### Steps
+
+1. Go to **Setup > User Interface > Sites and Domains > Sites**
+2. Click **New**
+3. Fill in the following fields:
+
+   | Field | Value |
+   |---|---|
+   | Site Label | `iRaiser Webhooks` |
+   | Site Name | `iraiserwebhooks` |
+   | Site Contact | *(System Administrator)* |
+   | Default Record Owner | *(System Administrator)* |
+   | Active | ✅ Checked |
+   | Active Site Home Page | `InMaintenance` |
+
+4. Click **Save**
+5. Ensure the site is **Active**
+
+---
+
+## Parent-Child Relationships
+
+### Overview
+
+The iRaiser Connector automatically handles hierarchical data processing where parent records are created before their children. This is configured using the **Parent Table Lookup Mapping** field on the Data Table Definition.
+
+### How It Works
+
+When you define parent-child relationships, the connector:
+1. Identifies all Data Table Definitions for your connector
+2. Builds a dependency graph based on Parent Table Lookup Mappings
+3. Automatically sorts the definitions so parents are processed first
+4. Creates/updates parent records before their children
+5. Uses the mapped lookup fields to establish relationships
+
+> ⚠️ **Circular Dependency Detection:** If circular dependencies are detected (e.g., Object A depends on Object B, and Object B depends on Object A), the connector will throw an error and halt processing.
+
+### Configuration Format
+
+The **Parent Table Lookup Mapping** field uses the following format:
+
+```
+ParentObjectAPI->ChildLookupField
+```
+
+- **ParentObjectAPI**: The API name of the parent Salesforce object
+- **ChildLookupField**: The API name of the lookup field on the child object that references the parent
+
+Multiple parent relationships can be defined, one per line.
+
+### Example: Three-Level Hierarchy
+
+For a typical donation scenario with Account → Contact → Opportunity:
+
+**Account DTD (Root):**
+| Field | Value |
+|---|---|
+| Parent Table Lookup Mapping | (blank - no parent) |
+
+**Contact DTD (Child of Account):**
+| Field | Value |
+|---|---|
+| Parent Table Lookup Mapping | `Account->AccountId` |
+
+**Opportunity DTD (Child of Account):**
+| Field | Value |
+|---|---|
+| Parent Table Lookup Mapping | `Account->AccountId` |
+
+This ensures that:
+1. Account records are created/updated first
+2. Then Contact records (linked to their Accounts)
+3. Finally Opportunity records (linked to their Accounts)
+
+---
+
+## Testing Your Configuration
+
+Before going live, test your iRaiser Connector configuration:
+
+1. **Verify Data Connector** - Ensure it's created with type "iRaiser Connector"
+2. **Verify Token** - Confirm the iRaiser Token is configured in Mobee Settings
+3. **Verify Site** - Confirm the Salesforce Site is created and active
+4. **Test with Sample Payload** - Use the iRaiser sandbox to send test webhook calls
+5. **Validate Field Mappings** - Confirm all expected fields are populated correctly
+6. **Test Parent-Child Relationships** - Verify hierarchical data is processed in the correct order
+
+> 💡 Start with a small subset of data and gradually expand as you validate the integration.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### Webhook Returns 403 Forbidden
+
+**Symptoms:** HTTP 403 response with "Invalid token" message
+
+**Causes:**
+- Incorrect iRaiser Token in Settings
+- Invalid securetoken calculation
+- Missing or incorrect headers
+
+**Solution:**
+1. Verify the iRaiser Token in Mobee Settings
+2. Ensure iRaiser is sending all three required headers: `securelogin`, `securetimestamp`, `securetoken`
+3. Verify the token calculation: MD5(`securelogin` + `iRaiserToken` + `securetimestamp`).toLowerCase()
+4. Check the timestamp format: must be ISO 8601 UTC format
+
+#### Records Not Created/Updated
+
+**Symptoms:** Webhook returns 202 Accepted but no records are created
+
+**Causes:**
+- Missing Data Table Definitions
+- No Data Attribute Mappings configured
+- Field-level security issues
+- Missing required fields
+- Site not active or misconfigured
+
+**Solution:**
+1. Verify Data Table Definitions exist for the target objects
+2. Check that Data Attribute Mappings are configured for all required fields
+3. Ensure the integration user has create/update permissions on the target objects
+4. Verify the Salesforce Site is active
+
+#### Duplicate Records
+
+**Symptoms:** Multiple records created for the same iRaiser contact
+
+**Causes:**
+- No unique identifier fields configured
+- Unique identifier field not mapped correctly
+- Different unique identifier values between syncs
+
+**Solution:**
+1. Configure at least one **Unique Identifier** mapping per object
+2. Ensure the mapped field contains a consistent, unique value from iRaiser
+3. Consider using the iRaiser ID as an external ID field in Salesforce
+
+#### Parent-Child Processing Order Issues
+
+**Symptoms:** Child records created before parents, causing lookup errors
+
+**Causes:**
+- Missing or incorrect Parent Table Lookup Mapping
+- Circular dependencies in Data Table Definitions
+
+**Solution:**
+1. Verify Parent Table Lookup Mapping is configured for all child objects
+2. Review the dependency graph to ensure valid hierarchy
+
+---
+
+*Last updated: August 2026*

--- a/i18n/esp/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
+++ b/i18n/esp/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
@@ -1,0 +1,54 @@
+# Conector iRaiser
+
+## Introducción
+
+El conector **iRaiser Connector** permite a los usuarios de Salesforce recibir datos de donaciones y donantes de iRaiser directamente en Salesforce en tiempo real mediante una integración segura por webhook. A diferencia de otros conectores de datos que utilizan un enfoque basado en búsqueda donde los usuarios recuperan datos activamente, el conector iRaiser opera bajo un **modelo push** donde iRaiser envía automáticamente datos a Salesforce cada vez que ocurren cambios.
+
+🌐 Documentación de iRaiser: https://www.iraiser.eu/
+
+> ✅ Caso de uso típico: Crear o actualizar automáticamente registros de **Contacto**, **Cuenta**, **Oportunidad** u objetos de donante personalizados en Salesforce cuando se crean o modifican donaciones o información de donantes en iRaiser.
+
+---
+
+## ¿Cómo funciona?
+
+### Integración por Webhook
+
+El conector iRaiser recibe datos de iRaiser mediante llamadas HTTP POST de webhook. Cuando un evento ocurre en iRaiser (como una nueva donación, actualización de contacto o pago recurrente), iRaiser envía los datos a un endpoint designado en Salesforce.
+
+El conector:
+1. Valida la solicitud entrante utilizando autenticación basada en tokens
+2. Procesa la carga JSON de iRaiser
+3. Coincide o crea registros en los objetos Salesforce apropiados
+4. Maneja automáticamente las relaciones padre-hijo
+5. Registra todas las actividades para monitoreo y solución de problemas
+
+### Autenticación
+
+El conector utiliza **autenticación basada en tokens** para asegurar las comunicaciones por webhook. Un token secreto compartido configurado en Salesforce se utiliza para validar cada solicitud entrante de iRaiser.
+
+Cada solicitud incluye tres encabezados de seguridad que se validan:
+- `securelogin` — Inicio de sesión de iRaiser
+- `securetimestamp` — Marca de tiempo UTC actual
+- `securetoken` — Hash MD5 generado a partir del token y los detalles de la solicitud
+
+> ℹ️ La autenticación es manejada automáticamente por el conector. No se requiere configuración del lado del cliente.
+
+### Flujo de Datos
+
+El conector iRaiser procesa datos a través de estos objetos personalizados clave:
+
+- **[Data Connector](3-data-connector-module-configuration.md#create-a-data-connector)** — Identifica esto como una integración de iRaiser definiendo el tipo de conector.
+- **[Data Table Definition](8-iraiser-connector-configuration.md#data-table-definition)** — Vincula el conector a objetos de Salesforce (Ejemplo: Contacto, Cuenta, Oportunidad) y define relaciones padre-hijo.
+- **[Data Attribute Mapping](8-iraiser-connector-configuration.md#data-attribute-mappings)** — Mapea campos de la carga JSON de iRaiser a campos de Salesforce, definiendo cómo se importan los datos a los registros de Salesforce.
+
+### Procesamiento Asíncrono
+
+Para garantizar escalabilidad y confiabilidad, el conector utiliza **Eventos de Plataforma** de Salesforce para procesamiento asíncrono. Esto significa:
+
+- Las solicitudes de webhook son aceptadas inmediatamente (respuesta HTTP 202)
+- El procesamiento real de registros ocurre en segundo plano
+- Grandes volúmenes de datos pueden ser manejados sin impactar la experiencia del usuario
+- Las operaciones fallidas se reintentan automáticamente
+
+---

--- a/i18n/esp/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
+++ b/i18n/esp/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
@@ -1,0 +1,398 @@
+# Configuración del Conector iRaiser
+
+## Descripción General
+
+> ⚠️ **Requisito previo:** Antes de configurar este conector, asegúrese de que la **Configuración General** esté completa.  
+> Consulte [Configuración General](3-data-connector-module-configuration.md) para los pasos de asignación de conjuntos de permisos y creación de un Conector de Datos.
+
+1. [**Crear el Conector de Datos**](#data-connector) – Configurar el registro del conector con el tipo "iRaiser Connector"
+2. [**Almacenar el Token de iRaiser**](#store-the-iraiser-token) – Configurar el token de seguridad en Configuración
+3. [**Crear Definiciones de Tabla de Datos**](#data-table-definition) – Vincular datos de iRaiser a objetos de Salesforce
+4. [**Configurar Mapeos de Atributos de Datos**](#data-attribute-mappings) – Mapear campos JSON de iRaiser a campos de Salesforce
+5. [**Crear el Sitio Público para Recepción de Webhooks**](#create-the-public-site-for-webhook-reception) – Habilitar la recepción de webhooks
+
+En la siguiente sección, examinará cada uno de estos pasos de configuración.
+
+---
+
+## Conector de Datos
+
+### Crear el Registro del Conector de Datos
+
+El registro del Conector de Datos identifica esto como una integración de iRaiser.
+
+#### Campos Requeridos
+
+| Campo | Significado | Valor a Establecer |
+|-------|-------------|--------------------|
+| **Nombre** | Identificador único para este conector | Ejemplo: `iRaiser Production` o `iRaiser Sandbox` |
+| **Tipo de Conector** | Tipo de conector | Seleccione `iRaiser Connector` de la lista desplegable |
+
+#### Configuración de Ejemplo
+
+| Campo | Valor de Ejemplo |
+|-------|------------------|
+| Nombre | `iRaiser Production` |
+| Tipo de Conector | `iRaiser Connector` |
+
+#### Pasos
+
+1. Vaya a la pestaña **Connectores de Datos**
+2. Haga clic en **Nuevo**
+3. Ingrese un Nombre (ej. "iRaiser Production")
+4. Seleccione `iRaiser Connector` como Tipo de Conector
+5. Guarde el registro
+
+---
+
+## Almacenar el Token de iRaiser
+
+### Configurar el Token de Seguridad
+
+El conector iRaiser utiliza un token secreto compartido para validar solicitudes entrantes de webhook. Este token debe ser configurado en los metadatos personalizados de Configuración de Mobee.
+
+#### Campos Requeridos
+
+| Campo | Significado | Valor a Establecer |
+|-------|-------------|--------------------|
+| **iRaiser Token** | Clave secreta compartida para autenticación de webhook | El token proporcionado por iRaiser |
+
+#### Pasos
+
+1. Vaya a **Configuración** → **Tipos de Metadatos Personalizados**
+2. Haga clic en **Administrar Registros** junto a **Configuración de Mobee**
+3. Edite el registro **Configuración** predeterminado (o cree uno nuevo)
+4. Ingrese el Token de iRaiser en el campo **iRaiser Token**
+5. Guarde el registro
+
+> 🔐 **Nota de Seguridad:** Este token se utiliza para validar el encabezado `securetoken` en solicitudes entrantes de webhook. Manténgalo seguro y nunca lo exponga en código del lado del cliente.
+
+---
+
+## Definición de Tabla de Datos
+
+### Descripción General
+
+Las definiciones de tabla de datos vinculan datos de iRaiser a objetos de Salesforce. Para el conector iRaiser, cada definición especifica qué objeto de Salesforce recibirá datos de la carga del webhook.
+
+El conector admite el procesamiento de múltiples objetos en una sola llamada de webhook, con manejo automático de relaciones padre-hijo.
+
+### Campos Requeridos
+
+| Campo | Significado | Valor a Establecer |
+|-------|-------------|--------------------|
+| **Conector de Datos** | Vincula esta definición de tabla al conector | Seleccione su Conector iRaiser |
+| **Nombre del Objeto** | El objeto de Salesforce donde se crearán/actualizarán los registros | Ingrese el Nombre de API del Objeto. Ejemplo: `Account`, `Contact`, `Opportunity` |
+| **Tipo de Registro del Objeto** *(opcional)* | Limita el procesamiento a tipos de registro específicos | Nombres de Desarrollador separados por comas |
+| **Mapeo de Búsqueda de Tabla Padre** *(opcional)* | Define relaciones padre-hijo para procesamiento jerárquico | Formato: `APIObjetoPadre->CampoBúsquedaHijo` (uno por línea) |
+
+> 💡 Si su org **no usa** tipos de registro en el objeto designado, deje **Tipo de Registro del Objeto** en blanco.  
+> Al completar **Tipo de Registro del Objeto**, ingrese el **Nombre de Desarrollador**, no la etiqueta.  
+> Ejemplo: `Business_Account, PersonAccount`
+
+### Configuración de Ejemplo
+
+#### Para un Objeto Contacto (Hijo de Cuenta)
+
+| Campo | Valor de Ejemplo |
+|-------|------------------|
+| Conector de Datos | *iRaiser Production* |
+| Nombre del Objeto | `Contact` |
+| Tipo de Registro del Objeto | (en blanco) |
+| Mapeo de Búsqueda de Tabla Padre | `Account->AccountId` |
+
+#### Para un Objeto Cuenta (Raíz)
+
+| Campo | Valor de Ejemplo |
+|-------|------------------|
+| Conector de Datos | *iRaiser Production* |
+| Nombre del Objeto | `Account` |
+| Tipo de Registro del Objeto | `Business_Account` |
+| Mapeo de Búsqueda de Tabla Padre | (en blanco - este es un objeto raíz) |
+
+#### Para un Objeto Oportunidad (Hijo de Cuenta y Contacto)
+
+| Campo | Valor de Ejemplo |
+|-------|------------------|
+| Conector de Datos | *iRaiser Production* |
+| Nombre del Objeto | `Opportunity` |
+| Tipo de Registro del Objeto | `Donation` |
+| Mapeo de Búsqueda de Tabla Padre | `Account->AccountId` |
+
+### Pasos
+
+1. Vaya a la pestaña **Definiciones de Tabla de Datos**
+2. Haga clic en **Nuevo**
+3. Seleccione su Conector iRaiser en el campo **Conector de Datos**
+4. Ingrese el **Nombre del Objeto** de Salesforce (nombre de API)
+5. Opcionalmente especifique **Tipo de Registro del Objeto** si necesita filtrar por tipo de registro
+6. Si este objeto tiene relaciones padre, configure el **Mapeo de Búsqueda de Tabla Padre**
+7. Guarde el registro
+
+---
+
+## Mapeos de Atributos de Datos
+
+### Descripción General
+
+Los mapeos de atributos de datos definen cómo los campos de la carga JSON de iRaiser se mapean a campos de objetos de Salesforce. El conector iRaiser utiliza **notación de puntos** para acceder a campos anidados en la estructura JSON.
+
+> 💡 Solo los campos con los mapeos apropiados se poblarán en los registros de Salesforce. Cada mapeo vincula una ruta JSON específica a un campo de Salesforce.
+
+### Campos Clave
+
+| Campo | Significado | Valor a Establecer |
+|-------|-------------|--------------------|
+| **Definición de Tabla de Datos** | Vincula este mapeo a la definición de tabla correspondiente | Seleccione el registro *Definición de Tabla de Datos* relacionado |
+| **Campo de Objeto SF** | Campo de Salesforce donde se debe almacenar el valor | Nombre de Desarrollador del campo (Ejemplo: `FirstName`, `LastName`, `Email`) |
+| **Campo API** | Ruta del campo desde la carga JSON de iRaiser | Ruta del campo JSON usando notación de puntos (Ejemplo: `contact.firstname`, `contact.lastname`) |
+| **Es Identificador Único** | Marca este campo como identificador único para coincidencia de registros | Marque para campos que identifiquen de manera única registros (ej. ID de iRaiser, Email) |
+
+#### 1. Establecer el Campo de Objeto SF en el Mapeo de Atributos de Datos
+
+- Este es el nombre de API interno del campo de Salesforce que desea poblar.
+- Debe existir en el objeto asociado a su Definición de Tabla de Datos.
+- Puede encontrarlo en **Administrador de Objetos → [Su Objeto] → Campos y Relaciones**.
+
+📌 <u>*Ejemplo:*</u>
+
+Para mapear el nombre del contacto, establezca el **Campo de Objeto SF** en `FirstName`.
+
+#### 2. Establecer el Campo API en el Mapeo de Atributos de Datos
+
+Esta es la ruta exacta del campo tal como es devuelta por la API de iRaiser, usando **notación de puntos** para acceder a objetos anidados.
+
+- Use notación de puntos para recorrer la estructura JSON
+- Asegúrese de que el campo exista en la carga del webhook
+
+📌 <u>*Ejemplo:*</u>
+
+<details>
+<summary>Ver ejemplo de carga JSON de iRaiser</summary>
+
+```json
+Ejemplo de carga de webhook:
+
+{
+  "event": "contact.updated",
+  "data": {
+    "contact": {
+      "id": "12345",
+      "firstname": "John",
+      "lastname": "Doe",
+      "email": "john.doe@example.com",
+      "phone": "+33123456789",
+      "account": {
+        "id": "67890",
+        "name": "Acme Corporation",
+        "address": {
+          "street": "123 Main Street",
+          "city": "Paris",
+          "postalcode": "75001",
+          "country": "France"
+        }
+      }
+    }
+  },
+  "timestamp": "2025-08-17T10:00:00Z"
+}
+```
+
+</details>
+
+| Campo de Objeto SF | Campo API | Es Identificador Único |
+|-------------------|------------|----------------------|
+| FirstName | `contact.firstname` | No |
+| LastName | `contact.lastname` | No |
+| Email | `contact.email` | Sí |
+| Phone | `contact.phone` | No |
+| iRaiser_Id__c | `contact.id` | Sí |
+
+#### 3. Ejemplo de Registros de Mapeo de Atributos de Datos
+
+Para un objeto Contacto que recibe datos de iRaiser:
+
+| Definición de Tabla de Datos | Campo de Objeto SF | Campo API | Es Identificador Único |
+|---|---|---|---|
+| iRaiser Contact | FirstName | contact.firstname | (no marcado) |
+| iRaiser Contact | LastName | contact.lastname | (no marcado) |
+| iRaiser Contact | Email | contact.email | ✅ (marcado) |
+| iRaiser Contact | Phone | contact.phone | (no marcado) |
+| iRaiser Contact | iRaiser_Id__c | contact.id | ✅ (marcado) |
+
+Para un objeto Cuenta:
+
+| Definición de Tabla de Datos | Campo de Objeto SF | Campo API | Es Identificador Único |
+|---|---|---|---|
+| iRaiser Account | Name | contact.account.name | (no marcado) |
+| iRaiser Account | iRaiser_Account_Id__c | contact.account.id | ✅ (marcado) |
+| iRaiser Account | BillingStreet | contact.account.address.street | (no marcado) |
+| iRaiser Account | BillingCity | contact.account.address.city | (no marcado) |
+| iRaiser Account | BillingPostalCode | contact.account.address.postalcode | (no marcado) |
+
+> 💡 **Mejor Práctica:** Siempre mapee el ID externo de iRaiser (ej. `contact.id`) a un campo personalizado en Salesforce y márquelo como **Identificador Único**. Esto garantiza una coincidencia correcta de registros entre sincronizaciones y evita duplicados.
+
+---
+
+## Crear el Sitio Público para Recepción de Webhooks
+
+El conector iRaiser recibe llamadas de webhook de iRaiser, lo que requiere un endpoint públicamente accesible en Salesforce. Esto se logra creando y activando un Sitio de Salesforce.
+
+> ⚠️ Pueden aparecer pequeñas diferencias dependiendo de su edición de Salesforce, el principio sigue siendo el mismo.
+
+### Pasos
+
+1. Vaya a **Configuración > Interfaz de Usuario > Sitios y Dominios > Sitios**
+2. Haga clic en **Nuevo**
+3. Complete los siguientes campos:
+
+   | Campo | Valor |
+   |---|---|
+   | Etiqueta del Sitio | `iRaiser Webhooks` |
+   | Nombre del Sitio | `iraiserwebhooks` |
+   | Contacto del Sitio | *(Administrador del Sistema)* |
+   | Propietario de Registro Predeterminado | *(Administrador del Sistema)* |
+   | Activo | ✅ Marcado |
+   | Página de Inicio del Sitio Activo | `InMaintenance` |
+
+4. Haga clic en **Guardar**
+5. Asegúrese de que el sitio esté **Activo**
+
+---
+
+## Relaciones Padre-Hijo
+
+### Descripción General
+
+El conector iRaiser maneja automáticamente el procesamiento jerárquico de datos donde los registros padre se crean antes que sus hijos. Esto se configura utilizando el campo **Mapeo de Búsqueda de Tabla Padre** en la Definición de Tabla de Datos.
+
+### Funcionamiento
+
+Cuando define relaciones padre-hijo, el conector:
+1. Identifica todas las Definiciones de Tabla de Datos para su conector
+2. Construye un grafo de dependencias basado en Mapeos de Búsqueda de Tabla Padre
+3. Ordena automáticamente las definiciones para que los padres sean procesados primero
+4. Crea/actualiza registros padre antes que sus hijos
+5. Utiliza campos de búsqueda mapeados para establecer relaciones
+
+> ⚠️ **Detección de Dependencia Circular:** Si se detectan dependencias circulares (ej. Objeto A depende de Objeto B, y Objeto B depende de Objeto A), el conector generará un error y detendrá el procesamiento.
+
+### Formato de Configuración
+
+El campo **Mapeo de Búsqueda de Tabla Padre** utiliza el siguiente formato:
+
+```
+APIObjetoPadre->CampoBúsquedaHijo
+```
+
+- **APIObjetoPadre:** El nombre de API del objeto padre de Salesforce
+- **CampoBúsquedaHijo:** El nombre de API del campo de búsqueda en el objeto hijo que referencia al padre
+
+Se pueden definir múltiples relaciones padre, una por línea.
+
+### Ejemplo: Jerarquía de Tres Niveles
+
+Para un escenario de donación típico con Cuenta → Contacto → Oportunidad:
+
+**DTD Cuenta (Raíz):**
+| Campo | Valor |
+|---|---|
+| Mapeo de Búsqueda de Tabla Padre | (en blanco - sin padre) |
+
+**DTD Contacto (Hijo de Cuenta):**
+| Campo | Valor |
+|---|---|
+| Mapeo de Búsqueda de Tabla Padre | `Account->AccountId` |
+
+**DTD Oportunidad (Hijo de Cuenta):**
+| Campo | Valor |
+|---|---|
+| Mapeo de Búsqueda de Tabla Padre | `Account->AccountId` |
+
+Esto garantiza que:
+1. Los registros de Cuenta se crean/actualizan primero
+2. Luego los registros de Contacto (vinculados a sus Cuentas)
+3. Finalmente los registros de Oportunidad (vinculados a sus Cuentas)
+
+---
+
+## Probar Su Configuración
+
+Antes de pasar a producción, pruebe su configuración del conector iRaiser:
+
+1. **Verifique el Conector de Datos** - Asegúrese de que esté creado con el tipo "iRaiser Connector"
+2. **Verifique el Token** - Confirme que el Token de iRaiser esté configurado en Configuración de Mobee
+3. **Verifique el Sitio** - Confirme que el Sitio de Salesforce esté creado y activo
+4. **Pruebe con una Carga de Ejemplo** - Use el sandbox de iRaiser para enviar llamadas de webhook de prueba
+5. **Valide los Mapeos de Campos** - Confirme que todos los campos esperados se poblan correctamente
+6. **Pruebe las Relaciones Padre-Hijo** - Verifique que los datos jerárquicos se procesen en el orden correcto
+
+> 💡 Comience con un pequeño subconjunto de datos y expándalo gradualmente a medida que valide la integración.
+
+---
+
+## Solución de Problemas
+
+### Problemas Comunes
+
+#### El Webhook Devuelve 403 Prohibido
+
+**Síntomas:** Respuesta HTTP 403 con el mensaje "Token no válido"
+
+**Causas:**
+- Token de iRaiser incorrecto en Configuración
+- Cálculo de securetoken no válido
+- Encabezados faltantes o incorrectos
+
+**Solución:**
+1. Verifique el Token de iRaiser en Configuración de Mobee
+2. Asegúrese de que iRaiser esté enviando los tres encabezados requeridos: `securelogin`, `securetimestamp`, `securetoken`
+3. Verifique el cálculo del token: MD5(`securelogin` + `iRaiserToken` + `securetimestamp`).toLowerCase()
+4. Verifique el formato de la marca de tiempo: debe estar en formato ISO 8601 UTC
+
+#### No se Crean/Actualizan Registros
+
+**Síntomas:** El webhook devuelve 202 Aceptado pero no se crean registros
+
+**Causas:**
+- Definiciones de Tabla de Datos faltantes
+- No hay Mapeos de Atributos de Datos configurados
+- Problemas de seguridad a nivel de campo
+- Campos requeridos faltantes
+- Sitio no activo o mal configurado
+
+**Solución:**
+1. Verifique que las Definiciones de Tabla de Datos existan para los objetos objetivo
+2. Verifique que los Mapeos de Atributos de Datos estén configurados para todos los campos requeridos
+3. Asegúrese de que el usuario de integración tenga permisos de creación/modificación en los objetos objetivo
+4. Verifique que el Sitio de Salesforce esté activo
+
+#### Registros Duplicados
+
+**Síntomas:** Múltiples registros creados para el mismo contacto de iRaiser
+
+**Causas:**
+- No hay campos de identificador único configurados
+- Campo de identificador único mapeado incorrectamente
+- Diferentes valores de identificador único entre sincronizaciones
+
+**Solución:**
+1. Configure al menos un mapeo de **Identificador Único** por objeto
+2. Asegúrese de que el campo mapeado contenga un valor único y consistente de iRaiser
+3. Considere usar el ID de iRaiser como campo de ID externo en Salesforce
+
+#### Problemas de Orden de Procesamiento Padre-Hijo
+
+**Síntomas:** Los registros hijos creados antes que los padres, causando errores de búsqueda
+
+**Causas:**
+- Mapeo de Búsqueda de Tabla Padre faltante o incorrecto
+- Dependencias circulares en las Definiciones de Tabla de Datos
+
+**Solución:**
+1. Verifique que el Mapeo de Búsqueda de Tabla Padre esté configurado para todos los objetos hijos
+2. Revise el grafo de dependencias para garantizar una jerarquía válida
+
+---
+
+*Última actualización: Agosto 2026*

--- a/i18n/fr/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/7-iraiser-connector-introduction.md
@@ -1,0 +1,54 @@
+# iRaiser Connector
+
+## Introduction
+
+Le connecteur **iRaiser Connector** permet aux utilisateurs Salesforce de recevoir en temps réel les données de dons et de donateurs d'iRaiser directement dans Salesforce via une intégration sécurisée par webhook. Contrairement aux autres connecteurs de données qui utilisent une approche basée sur la recherche où les utilisateurs récupèrent activement les données, le connecteur iRaiser fonctionne selon un **modèle push** où iRaiser envoie automatiquement les données à Salesforce chaque fois que des modifications se produisent.
+
+🌐 Documentation iRaiser : https://www.iraiser.eu/
+
+> ✅ Cas d'usage typique : Créer ou mettre à jour automatiquement des enregistrements **Contact**, **Compte**, **Opportunité** ou des objets donateur personnalisés dans Salesforce lorsque des dons ou des informations de donateur sont créés ou modifiés dans iRaiser.
+
+---
+
+## Comment ça fonctionne ?
+
+### Intégration Webhook
+
+Le connecteur iRaiser reçoit les données d'iRaiser via des appels HTTP POST de webhook. Lorsqu'un événement se produit dans iRaiser (tel qu'un nouveau don, une mise à jour de contact ou un paiement récurrent), iRaiser envoie les données à un point de terminaison désigné dans Salesforce.
+
+Le connecteur :
+1. Valide la requête entrante à l'aide d'une authentification basée sur des tokens
+2. Traite la charge utile JSON d'iRaiser
+3. Fait correspondre ou crée des enregistrements dans les objets Salesforce appropriés
+4. Gère automatiquement les relations parent-enfant
+5. Journalise toutes les activités pour le suivi et le dépannage
+
+### Authentification
+
+Le connecteur utilise **l'authentification par token** pour sécuriser les communications par webhook. Un token secret partagé configuré dans Salesforce est utilisé pour valider chaque requête entrante d'iRaiser.
+
+Chaque requête inclut trois en-têtes de sécurité qui sont validés :
+- `securelogin` — Identifiant de connexion iRaiser
+- `securetimestamp` — Horodatage UTC actuel
+- `securetoken` — Hash MD5 généré à partir du token et des détails de la requête
+
+> ℹ️ L'authentification est gérée automatiquement par le connecteur. Aucune configuration côté client n'est requise.
+
+### Flux de données
+
+Le connecteur iRaiser traite les données via ces objets personnalisés clés :
+
+- **[Data Connector](3-data-connector-module-configuration.md#create-a-data-connector)** – Identifie cela comme une intégration iRaiser en définissant le type de connecteur.
+- **[Data Table Definition](8-iraiser-connector-configuration.md#data-table-definition)** – Lie le connecteur aux objets Salesforce (Exemple : Contact, Compte, Opportunité) et définit les relations parent-enfant.
+- **[Data Attribute Mapping](8-iraiser-connector-configuration.md#data-attribute-mappings)** – Mappe les champs de la charge utile JSON d'iRaiser aux champs Salesforce, définissant comment les données sont importées dans les enregistrements Salesforce.
+
+### Traitement Asynchrone
+
+Pour garantir la scalabilité et la fiabilité, le connecteur utilise les **Événements de Plateforme** Salesforce pour un traitement asynchrone. Cela signifie :
+
+- Les requêtes de webhook sont acceptées immédiatement (réponse HTTP 202)
+- Le traitement réel des enregistrements se fait en arrière-plan
+- De grands volumes de données peuvent être gérés sans impacter l'expérience utilisateur
+- Les opérations échouées sont automatiquement réessayées
+
+---

--- a/i18n/fr/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/documentation-api/9 - Data Connector Module/8-iraiser-connector-configuration.md
@@ -1,0 +1,398 @@
+# Configuration du Connecteur iRaiser
+
+## Aperçu
+
+> ⚠️ **Prérequis :** Avant de configurer ce connecteur, assurez-vous que la **Configuration Générale** est terminée.  
+> Voir [Configuration Générale](3-data-connector-module-configuration.md) pour les étapes d'attribution des ensembles de permissions et de création d'un connecteur de données.
+
+1. [**Créer le Connecteur de Données**](#data-connector) – Configurez l'enregistrement du connecteur avec le type "iRaiser Connector"
+2. [**Stocker le Token iRaiser**](#store-the-iraiser-token) – Configurez le token de sécurité dans les paramètres
+3. [**Créer des Définitions de Table de Données**](#data-table-definition) – Liez les données iRaiser aux objets Salesforce
+4. [**Configurer les Mappages d'Attributs de Données**](#data-attribute-mappings) – Mappez les champs JSON d'iRaiser aux champs Salesforce
+5. [**Créer le Site Public pour la Réception des Webhooks**](#create-the-public-site-for-webhook-reception) – Activez la réception des webhooks
+
+Dans la section suivante, nous examinerons de plus près chacune de ces étapes de configuration.
+
+---
+
+## Connecteur de Données
+
+### Créer l'Enregistrement du Connecteur de Données
+
+L'enregistrement du connecteur de données identifie cela comme une intégration iRaiser.
+
+#### Champs Obligatoires
+
+| Champ | Signification | Valeur à Définir |
+|-------|--------------|------------------|
+| **Nom** | Identifiant unique pour ce connecteur | Exemple : `iRaiser Production` ou `iRaiser Sandbox` |
+| **Type de Connecteur** | Type de connecteur | Sélectionnez `iRaiser Connector` dans la liste déroulante |
+
+#### Configuration Exemple
+
+| Champ | Valeur Exemple |
+|-------|----------------|
+| Nom | `iRaiser Production` |
+| Type de Connecteur | `iRaiser Connector` |
+
+#### Étapes
+
+1. Allez dans l'onglet **Connecteurs de Données**
+2. Cliquez sur **Nouveau**
+3. Entrez un Nom (ex. "iRaiser Production")
+4. Sélectionnez `iRaiser Connector` comme Type de Connecteur
+5. Enregistrez l'enregistrement
+
+---
+
+## Stocker le Token iRaiser
+
+### Configurer le Token de Sécurité
+
+Le connecteur iRaiser utilise un token secret partagé pour valider les requêtes de webhook entrantes. Ce token doit être configuré dans les métadonnées personnalisées Mobee Settings.
+
+#### Champs Obligatoires
+
+| Champ | Signification | Valeur à Définir |
+|-------|--------------|------------------|
+| **iRaiser Token** | Clé secrète partagée pour l'authentification des webhooks | Le token fourni par iRaiser |
+
+#### Étapes
+
+1. Allez dans **Paramétrage** → **Types de Métadonnées Personnalisées**
+2. Cliquez sur **Gérer les Enregistrements** à côté de **Mobee Settings**
+3. Modifiez l'enregistrement **Paramètres** par défaut (ou créez-en un nouveau)
+4. Entrez le Token iRaiser dans le champ **iRaiser Token**
+5. Enregistrez l'enregistrement
+
+> 🔐 **Note de Sécurité :** Ce token est utilisé pour valider l'en-tête `securetoken` dans les requêtes de webhook entrantes. Gardez-le sécurisé et ne l'exposez jamais dans le code côté client.
+
+---
+
+## Définition de Table de Données
+
+### Aperçu
+
+Les définitions de table de données lient les données iRaiser aux objets Salesforce. Pour le connecteur iRaiser, chaque définition spécifie quel objet Salesforce recevra les données de la charge utile du webhook.
+
+Le connecteur prend en charge le traitement de plusieurs objets dans un seul appel de webhook, avec une gestion automatique des relations parent-enfant.
+
+### Champs Obligatoires
+
+| Champ | Signification | Valeur à Définir |
+|-------|--------------|------------------|
+| **Connecteur de Données** | Lie cette définition de table au connecteur | Sélectionnez votre connecteur iRaiser |
+| **Nom de l'Objet** | L'objet Salesforce où les enregistrements seront créés/mis à jour | Saisissez le Nom d'API de l'Objet. Exemple : `Account`, `Contact`, `Opportunity` |
+| **Type d'Enregistrement d'Objet** *(facultatif)* | Limite le traitement à des types d'enregistrement spécifiques | Noms du Développeur séparés par des virgules |
+| **Mappage de Recherche de Table Parente** *(facultatif)* | Définit les relations parent-enfant pour le traitement hiérarchique | Format : `APIObjetParent->ChampRechercheEnfant` (une par ligne) |
+
+> 💡 Si votre org **n'utilise pas** les types d'enregistrement sur l'objet désigné, laissez **Type d'Enregistrement d'Objet** vide.  
+> Lors du remplissage du **Type d'Enregistrement d'Objet**, entrez le **Nom du Développeur**, pas le libellé.  
+> Exemple : `Business_Account, PersonAccount`
+
+### Configuration Exemple
+
+#### Pour un Objet Contact (Enfant de Compte)
+
+| Champ | Valeur Exemple |
+|-------|----------------|
+| Connecteur de Données | *iRaiser Production* |
+| Nom de l'Objet | `Contact` |
+| Type d'Enregistrement d'Objet | (vide) |
+| Mappage de Recherche de Table Parente | `Account->AccountId` |
+
+#### Pour un Objet Compte (Racine)
+
+| Champ | Valeur Exemple |
+|-------|----------------|
+| Connecteur de Données | *iRaiser Production* |
+| Nom de l'Objet | `Account` |
+| Type d'Enregistrement d'Objet | `Business_Account` |
+| Mappage de Recherche de Table Parente | (vide - il s'agit d'un objet racine) |
+
+#### Pour un Objet Opportunité (Enfant de Compte et Contact)
+
+| Champ | Valeur Exemple |
+|-------|----------------|
+| Connecteur de Données | *iRaiser Production* |
+| Nom de l'Objet | `Opportunity` |
+| Type d'Enregistrement d'Objet | `Donation` |
+| Mappage de Recherche de Table Parente | `Account->AccountId` |
+
+### Étapes
+
+1. Allez dans l'onglet **Définitions de Table de Données**
+2. Cliquez sur **Nouveau**
+3. Sélectionnez votre connecteur iRaiser dans le champ **Connecteur de Données**
+4. Entrez le **Nom de l'Objet** Salesforce (nom d'API)
+5. Spécifiez éventuellement le **Type d'Enregistrement d'Objet** si vous devez filtrer par type d'enregistrement
+6. Si cet objet a des relations parent, configurez le **Mappage de Recherche de Table Parente**
+7. Enregistrez l'enregistrement
+
+---
+
+## Mappages d'Attributs de Données
+
+### Aperçu
+
+Les mappages d'attributs de données définissent comment les champs de la charge utile JSON d'iRaiser sont mappés aux champs des objets Salesforce. Le connecteur iRaiser utilise la **notation par points** pour accéder aux champs imbriqués dans la structure JSON.
+
+> 💡 Seuls les champs avec les mappages appropriés seront peuplés dans les enregistrements Salesforce. Chaque mappage lie un chemin JSON spécifique à un champ Salesforce.
+
+### Champs Clés
+
+| Champ | Signification | Valeur à Définir |
+|-------|--------------|------------------|
+| **Définition de Table de Données** | Lie ce mappage à la définition de table correspondante | Sélectionnez l'enregistrement *Définition de Table de Données* concerné |
+| **Champ Objet SF** | Champ Salesforce où la valeur doit être stockée | Nom du Développeur du champ (Exemple : `FirstName`, `LastName`, `Email`) |
+| **Champ API** | Chemin du champ depuis la charge utile JSON d'iRaiser | Chemin du champ JSON utilisant la notation par points (Exemple : `contact.firstname`, `contact.lastname`) |
+| **Est Identifiant Unique** | Marque ce champ comme un identifiant unique pour la correspondance des enregistrements | Cocher pour les champs qui identifient de manière unique les enregistrements (ex. : ID iRaiser, Email) |
+
+#### 1. Définir le Champ Objet SF dans le Mappage d'Attributs de Données
+
+- Il s'agit du nom d'API interne du champ Salesforce que vous souhaitez peupler.
+- Il doit exister sur l'objet associé à votre Définition de Table de Données.
+- Vous pouvez le trouver dans **Gestionnaire d'Objets → [Votre Objet] → Champs et Relations**.
+
+📌 <u>*Exemple :*</u>
+
+Pour mapper le prénom du contact, définissez le **Champ Objet SF** sur `FirstName`.
+
+#### 2. Définir le Champ API dans le Mappage d'Attributs de Données
+
+Il s'agit du chemin exact du champ tel que retourné par l'API iRaiser, en utilisant la **notation par points** pour accéder aux objets imbriqués.
+
+- Utilisez la notation par points pour parcourir la structure JSON
+- Assurez-vous que le champ existe dans la charge utile du webhook
+
+📌 <u>*Exemple :*</u>
+
+<details>
+<summary>Voir un exemple de charge utile JSON iRaiser</summary>
+
+```json
+Exemple de charge utile de webhook :
+
+{
+  "event": "contact.updated",
+  "data": {
+    "contact": {
+      "id": "12345",
+      "firstname": "John",
+      "lastname": "Doe",
+      "email": "john.doe@example.com",
+      "phone": "+33123456789",
+      "account": {
+        "id": "67890",
+        "name": "Acme Corporation",
+        "address": {
+          "street": "123 Main Street",
+          "city": "Paris",
+          "postalcode": "75001",
+          "country": "France"
+        }
+      }
+    }
+  },
+  "timestamp": "2025-08-17T10:00:00Z"
+}
+```
+
+</details>
+
+| Champ Objet SF | Champ API | Est Identifiant Unique |
+|---------------|------------|------------------------|
+| FirstName | `contact.firstname` | Non |
+| LastName | `contact.lastname` | Non |
+| Email | `contact.email` | Oui |
+| Phone | `contact.phone` | Non |
+| iRaiser_Id__c | `contact.id` | Oui |
+
+#### 3. Exemple d'Enregistrements de Mappage d'Attributs de Données
+
+Pour un objet Contact recevant des données iRaiser :
+
+| Définition de Table de Données | Champ Objet SF | Champ API | Est Identifiant Unique |
+|---|---|---|---|
+| iRaiser Contact | FirstName | contact.firstname | (non coché) |
+| iRaiser Contact | LastName | contact.lastname | (non coché) |
+| iRaiser Contact | Email | contact.email | ✅ (coché) |
+| iRaiser Contact | Phone | contact.phone | (non coché) |
+| iRaiser Contact | iRaiser_Id__c | contact.id | ✅ (coché) |
+
+Pour un objet Compte :
+
+| Définition de Table de Données | Champ Objet SF | Champ API | Est Identifiant Unique |
+|---|---|---|---|
+| iRaiser Account | Name | contact.account.name | (non coché) |
+| iRaiser Account | iRaiser_Account_Id__c | contact.account.id | ✅ (coché) |
+| iRaiser Account | BillingStreet | contact.account.address.street | (non coché) |
+| iRaiser Account | BillingCity | contact.account.address.city | (non coché) |
+| iRaiser Account | BillingPostalCode | contact.account.address.postalcode | (non coché) |
+
+> 💡 **Meilleure Pratique :** Mappez toujours l'ID externe iRaiser (ex. : `contact.id`) vers un champ personnalisé dans Salesforce et marquez-le comme **Identifiant Unique**. Cela garantit une correspondance correcte des enregistrements entre les synchronisations et évite les doublons.
+
+---
+
+## Créer le Site Public pour la Réception des Webhooks
+
+Le connecteur iRaiser reçoit les appels de webhook d'iRaiser, ce qui nécessite un point de terminaison publiquement accessible dans Salesforce. Cela est réalisé en créant et en activant un Site Salesforce.
+
+> ⚠️ De légères différences peuvent apparaître en fonction de votre édition Salesforce — le principe reste le même.
+
+### Étapes
+
+1. Allez dans **Paramétrage > Interface Utilisateur > Sites et Domaines > Sites**
+2. Cliquez sur **Nouveau**
+3. Remplissez les champs suivants :
+
+   | Champ | Valeur |
+   |---|---|
+   | Libellé du Site | `iRaiser Webhooks` |
+   | Nom du Site | `iraiserwebhooks` |
+   | Contact du Site | *(Administrateur Système)* |
+   | Propriétaire d'Enregistrement par Défaut | *(Administrateur Système)* |
+   | Actif | ✅ Coché |
+   | Page d'Accueil du Site Active | `InMaintenance` |
+
+4. Cliquez sur **Enregistrer**
+5. Assurez-vous que le site est **Actif**
+
+---
+
+## Relations Parent-Enfant
+
+### Aperçu
+
+Le connecteur iRaiser gère automatiquement le traitement hiérarchique des données où les enregistrements parents sont créés avant leurs enfants. Cela est configuré en utilisant le champ **Mappage de Recherche de Table Parente** sur la Définition de Table de Données.
+
+### Fonctionnement
+
+Lorsque vous définissez des relations parent-enfant, le connecteur :
+1. Identifie toutes les Définitions de Table de Données pour votre connecteur
+2. Construit un graphe de dépendances basé sur les Mappages de Recherche de Table Parente
+3. Trie automatiquement les définitions pour que les parents soient traités en premier
+4. Crée/met à jour les enregistrements parents avant leurs enfants
+5. Utilise les champs de recherche mappés pour établir les relations
+
+> ⚠️ **Détection de Dépendance Circulaire :** Si des dépendances circulaires sont détectées (ex. : l'Objet A dépend de l'Objet B, et l'Objet B dépend de l'Objet A), le connecteur génère une erreur et arrête le traitement.
+
+### Format de Configuration
+
+Le champ **Mappage de Recherche de Table Parente** utilise le format suivant :
+
+```
+APIObjetParent->ChampRechercheEnfant
+```
+
+- **APIObjetParent** : Le nom d'API de l'objet Salesforce parent
+- **ChampRechercheEnfant** : Le nom d'API du champ de recherche sur l'objet enfant qui référence le parent
+
+Plusieurs relations parent peuvent être définies, une par ligne.
+
+### Exemple : Hiérarchie à Trois Niveaux
+
+Pour un scénario de don typique avec Compte → Contact → Opportunité :
+
+**DTD Compte (Racine) :**
+| Champ | Valeur |
+|---|---|
+| Mappage de Recherche de Table Parente | (vide - pas de parent) |
+
+**DTD Contact (Enfant de Compte) :**
+| Champ | Valeur |
+|---|---|
+| Mappage de Recherche de Table Parente | `Account->AccountId` |
+
+**DTD Opportunité (Enfant de Compte) :**
+| Champ | Valeur |
+|---|---|
+| Mappage de Recherche de Table Parente | `Account->AccountId` |
+
+Cela garantit que :
+1. Les enregistrements Compte sont créés/mis à jour en premier
+2. Ensuite les enregistrements Contact (liés à leurs Comptes)
+3. Enfin les enregistrements Opportunité (liés à leurs Comptes)
+
+---
+
+## Tester Votre Configuration
+
+Avant de passer en production, testez votre configuration du connecteur iRaiser :
+
+1. **Vérifiez le Connecteur de Données** - Assurez-vous qu'il est créé avec le type "iRaiser Connector"
+2. **Vérifiez le Token** - Confirmez que le Token iRaiser est configuré dans Mobee Settings
+3. **Vérifiez le Site** - Confirmez que le Site Salesforce est créé et actif
+4. **Testez avec une Charge Utile Exemple** - Utilisez le bac à sable iRaiser pour envoyer des appels de webhook de test
+5. **Validez les Mappages de Champs** - Confirmez que tous les champs attendus sont peuplés correctement
+6. **Testez les Relations Parent-Enfant** - Vérifiez que les données hiérarchiques sont traitées dans le bon ordre
+
+> 💡 Commencez avec un petit sous-ensemble de données et élargissez progressivement à mesure que vous validez l'intégration.
+
+---
+
+## Dépannage
+
+### Problèmes Courants
+
+#### Le Webhook Retourne 403 Interdit
+
+**Symptômes :** Réponse HTTP 403 avec le message "Token invalide"
+
+**Causes :**
+- Token iRaiser incorrect dans les Paramètres
+- Calcul du securetoken invalide
+- En-têtes manquants ou incorrects
+
+**Solution :**
+1. Vérifiez le Token iRaiser dans Mobee Settings
+2. Assurez-vous qu'iRaiser envoie les trois en-têtes requis : `securelogin`, `securetimestamp`, `securetoken`
+3. Vérifiez le calcul du token : MD5(`securelogin` + `iRaiserToken` + `securetimestamp`).toLowerCase()
+4. Vérifiez le format de l'horodatage : doit être au format ISO 8601 UTC
+
+#### Aucun Enregistrement Créé/Mis à Jour
+
+**Symptômes :** Le webhook retourne 202 Accepté mais aucun enregistrement n'est créé
+
+**Causes :**
+- Définitions de Table de Données manquantes
+- Aucun Mappage d'Attributs de Données configuré
+- Problèmes de sécurité au niveau des champs
+- Champs requis manquants
+- Site non actif ou mal configuré
+
+**Solution :**
+1. Vérifiez que les Définitions de Table de Données existent pour les objets cibles
+2. Vérifiez que les Mappages d'Attributs de Données sont configurés pour tous les champs requis
+3. Assurez-vous que l'utilisateur d'intégration a les permissions de création/modification sur les objets cibles
+4. Vérifiez que le Site Salesforce est actif
+
+#### Enregistrements en Double
+
+**Symptômes :** Plusieurs enregistrements créés pour le même contact iRaiser
+
+**Causes :**
+- Aucun champ identifiant unique configuré
+- Champ identifiant unique mal mappé
+- Valeurs différentes d'identifiant unique entre les synchronisations
+
+**Solution :**
+1. Configurez au moins un mappage **Identifiant Unique** par objet
+2. Assurez-vous que le champ mappé contient une valeur unique et cohérente d'iRaiser
+3. Envisagez d'utiliser l'ID iRaiser comme champ ID externe dans Salesforce
+
+#### Problèmes d'Ordre de Traitement Parent-Enfant
+
+**Symptômes :** Les enregistrements enfants créés avant les parents, causant des erreurs de recherche
+
+**Causes :**
+- Mappage de Recherche de Table Parente manquant ou incorrect
+- Dépendances circulaires dans les Définitions de Table de Données
+
+**Solution :**
+1. Vérifiez que le Mappage de Recherche de Table Parente est configuré pour tous les objets enfants
+2. Vérifiez le graphe de dépendances pour garantir une hiérarchie valide
+
+---
+
+*Dernière mise à jour : Août 2026*


### PR DESCRIPTION
- Introduced the iRaiser Connector overview and functionality in Spanish and French.
- Added detailed configuration steps for the iRaiser Connector in both languages.
- Included sections on data flow, authentication, and troubleshooting for the iRaiser Connector.
- Ensured consistency in formatting and structure across language versions.